### PR TITLE
Update version to tag 1.14.0 for RHVoice

### DIFF
--- a/Firmware/system/br2_external/package/rhvoice/rhvoice.mk
+++ b/Firmware/system/br2_external/package/rhvoice/rhvoice.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RHVOICE_VERSION = ed7bf65b6861281b2a0f168a148200f870036164
+RHVOICE_VERSION = 1.14.0
 RHVOICE_SITE = https://github.com/RHVoice/RHVoice.git
 RHVOICE_LICENSE = GPLv2
 RHVOICE_SITE_METHOD = git

--- a/Firmware/system/config_brass.sh
+++ b/Firmware/system/config_brass.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 BR_RELEASE="buildroot-2024.02"
 


### PR DESCRIPTION
I've updated RHVoice to tag 1.14.0, which only has two commits.
It compiles and runs fine. Please review it.

https://github.com/RHVoice/RHVoice/commit/6795b79cfee111a58e6b41779f30ccf9aed78748
https://github.com/RHVoice/RHVoice/commit/d1d5fc6cc4aae2546840e3d802383020dc11e78e


73 de BD1AYT